### PR TITLE
show process id on terminal

### DIFF
--- a/app/server/services/job.ts
+++ b/app/server/services/job.ts
@@ -42,6 +42,8 @@ class Job {
         maxBuffer: 100 * 1024 * 1024
       });
 
+      console.log(`Process started with PID: ${n.pid}`);
+
       this.socketManager.emit(`job_started`, { room, data: n });
       n.stdout.on("data", chunk => {
         this.socketManager.emit(`job_output`, { room, data: chunk });
@@ -54,14 +56,16 @@ class Job {
       n.on("close", (code, signal) => {
         this.socketManager.emit(`job_close`, {
           room,
-          data: `Process closed with code ${code} by signal ${signal}`
+          data: `Process with PID ${n.pid ||
+            "--"} closed with code ${code} by signal ${signal}`
         });
       });
 
       n.on("exit", (code, signal) => {
         this.socketManager.emit(`job_exit`, {
           room,
-          data: `Process exited with code ${code} by signal ${signal}`
+          data: `Process with PID ${n.pid ||
+            "--"} exited with code ${code} by signal ${signal}`
         });
       });
     } catch (error) {

--- a/ui/src/components/shared/Sockets.tsx
+++ b/ui/src/components/shared/Sockets.tsx
@@ -59,6 +59,9 @@ function SocketsProvider(props: ISocketProviderProps) {
             const room = message.room;
             console.info(`Process started for cmd: ${room}`);
             updateJobProcess(room, message.data);
+            if (message.data.pid) {
+                updateJob(room, `--Process started with PID: ${message.data.pid}--\n\n`, true);
+            }
         });
         _socket.current.on(`job_output`, message => {
             const room = message.room;


### PR DESCRIPTION
Generally when process is killed by user, it shows which PID was killed. But if the process is long running, we don't know the PID.
Showing PID will be useful to debug or do something with process.
So with this PR, when we click on start, it displays the PID of started process.