### PR TITLE
Add copy paste into menu

### DIFF
--- a/app/electron/menu.ts
+++ b/app/electron/menu.ts
@@ -27,6 +27,8 @@ const editMenu: MenuItem = new MenuItem({
         shell.openPath(CONFIG_FILES.dbFile);
       },
     },
+    {role: "copy"},
+    {role: "paste"}
   ],
 });
 

--- a/app/electron/menu.ts
+++ b/app/electron/menu.ts
@@ -27,8 +27,10 @@ const editMenu: MenuItem = new MenuItem({
         shell.openPath(CONFIG_FILES.dbFile);
       },
     },
-    {role: "copy"},
-    {role: "paste"}
+    {role: "cut", visible: false},
+    {role: "copy", visible: false},
+    {role: "paste", visible:false},
+    {role: 'selectAll', visible: false}
   ],
 });
 


### PR DESCRIPTION
On macOS, the input fields in the new Project/Task forms are not allowing to paste or copy. This PR is to add those keyboard shortcuts to the App menu so the copy/cut/paste actions are integrated well.